### PR TITLE
Added REI Compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ repositories {
             includeGroup 'curse.maven'
         }
     }
+    maven { url "https://maven.shedaniel.me/" }
+    maven { url "https://maven.architectury.dev/" }
 }
 
 minecraft {
@@ -105,6 +107,14 @@ dependencies {
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:${curios_version}:api")
     compileOnly "mezz.jei:jei-${jei_mc_version}-common-api:${jei_version}"
     compileOnly "mezz.jei:jei-${jei_mc_version}-forge-api:${jei_version}"
+
+    runtimeOnly fg.deobf("dev.architectury:architectury-forge:${architectury_version}")
+    runtimeOnly fg.deobf("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}")
+    runtimeOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
+
+    compileOnly fg.deobf("dev.architectury:architectury-forge:${architectury_version}")
+    compileOnly fg.deobf("me.shedaniel.cloth:cloth-config-forge:${cloth_config_version}")
+    compileOnly fg.deobf("me.shedaniel:RoughlyEnoughItems-forge:${rei_version}")
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,3 +11,6 @@ jade_version=4573193
 curios_version=5.2.0-beta.3+1.20.1
 controllable_version=4598985
 framework_version=4718251
+architectury_version=9.2.14
+cloth_config_version=11.1.118
+rei_version=12.1.725

--- a/src/main/java/com/blakebr0/ironjetpacks/compat/rei/ReiCompat.java
+++ b/src/main/java/com/blakebr0/ironjetpacks/compat/rei/ReiCompat.java
@@ -1,0 +1,18 @@
+package com.blakebr0.ironjetpacks.compat.rei;
+
+import com.blakebr0.ironjetpacks.init.ModItems;
+import me.shedaniel.rei.api.common.entry.comparison.ItemComparatorRegistry;
+import me.shedaniel.rei.api.common.plugins.REIServerPlugin;
+import me.shedaniel.rei.forge.REIPluginCommon;
+
+@REIPluginCommon
+public class ReiCompat implements REIServerPlugin {
+
+    @Override
+    public void registerItemComparators(ItemComparatorRegistry registry) {
+        ModItems.JETPACK.ifPresent(registry::registerNbt);
+        ModItems.CELL.ifPresent(registry::registerNbt);
+        ModItems.THRUSTER.ifPresent(registry::registerNbt);
+        ModItems.CAPACITOR.ifPresent(registry::registerNbt);
+    }
+}


### PR DESCRIPTION
This PR provides REI compat for IronJetpacks when using REI as main recipe viewer.
This will help REI understand and filter IronJetpacks items based on their `CompoundTag` data.

Below is a before and after video demonstration:

https://github.com/BlakeBr0/IronJetpacks/assets/25727222/9c11fa5e-199f-4aca-a072-5020fbf73921

Thanks!