### PR TITLE
Fix jetpack crafting ingredients being broken with power data components

### DIFF
--- a/src/main/java/com/blakebr0/ironjetpacks/crafting/ingredient/JetpackComponentIngredient.java
+++ b/src/main/java/com/blakebr0/ironjetpacks/crafting/ingredient/JetpackComponentIngredient.java
@@ -1,13 +1,11 @@
 package com.blakebr0.ironjetpacks.crafting.ingredient;
 
-import com.blakebr0.ironjetpacks.IronJetpacks;
 import com.blakebr0.ironjetpacks.init.ModDataComponentTypes;
 import com.blakebr0.ironjetpacks.init.ModIngredientTypes;
 import com.blakebr0.ironjetpacks.init.ModItems;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.ItemStack;
@@ -39,19 +37,12 @@ public class JetpackComponentIngredient implements ICustomIngredient {
         if (input == null)
             return false;
 
-        DataComponentMap inputMap = input.getComponents();
-        ResourceLocation inputID = inputMap.get(ModDataComponentTypes.JETPACK_ID.get());
-        if(inputID == null)
+        var jetpackID = input.get(ModDataComponentTypes.JETPACK_ID.get());
+        if (jetpackID == null)
             return false;
 
-        return this.getItems().anyMatch(s -> {
-            DataComponentMap map = s.getComponents();
-            ResourceLocation itemID = map.get(ModDataComponentTypes.JETPACK_ID.get());
-            if(itemID == null)
-                return false;
-
-            return ItemStack.isSameItem(s, input) && itemID.getNamespace().equals(inputID.getNamespace()) && itemID.getPath().equals(inputID.getPath());
-        });
+        return this.getItems().anyMatch(s ->
+                ItemStack.isSameItem(s, input) && jetpackID.equals(s.get(ModDataComponentTypes.JETPACK_ID.get())));
     }
 
     @Override

--- a/src/main/java/com/blakebr0/ironjetpacks/crafting/ingredient/JetpackComponentIngredient.java
+++ b/src/main/java/com/blakebr0/ironjetpacks/crafting/ingredient/JetpackComponentIngredient.java
@@ -1,11 +1,13 @@
 package com.blakebr0.ironjetpacks.crafting.ingredient;
 
+import com.blakebr0.ironjetpacks.IronJetpacks;
 import com.blakebr0.ironjetpacks.init.ModDataComponentTypes;
 import com.blakebr0.ironjetpacks.init.ModIngredientTypes;
 import com.blakebr0.ironjetpacks.init.ModItems;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.core.component.DataComponentMap;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.StringRepresentable;
 import net.minecraft.world.item.ItemStack;
@@ -37,7 +39,19 @@ public class JetpackComponentIngredient implements ICustomIngredient {
         if (input == null)
             return false;
 
-        return this.getItems().anyMatch(s -> ItemStack.isSameItemSameComponents(s, input));
+        DataComponentMap inputMap = input.getComponents();
+        ResourceLocation inputID = inputMap.get(ModDataComponentTypes.JETPACK_ID.get());
+        if(inputID == null)
+            return false;
+
+        return this.getItems().anyMatch(s -> {
+            DataComponentMap map = s.getComponents();
+            ResourceLocation itemID = map.get(ModDataComponentTypes.JETPACK_ID.get());
+            if(itemID == null)
+                return false;
+
+            return ItemStack.isSameItem(s, input) && itemID.getNamespace().equals(inputID.getNamespace()) && itemID.getPath().equals(inputID.getPath());
+        });
     }
 
     @Override


### PR DESCRIPTION
Making a modpack for my friends I added a netherite jetpack in as a final upgrade, done with the smithing table in a custom recipe - When freshly spawned in and put directly in it works fine, but once it had power added to it it no longer works, as the ingredient test is checking for the exact same components, which includes the power level introduced when you charge it

[Kooha-2025-07-29-19-07-01.webm](https://github.com/user-attachments/assets/f2362c58-3d97-4dd3-a4ce-bec1ece15fc0)

With this PR it's fixed, by simply checking only the Jetpack ID:

[Kooha-2025-07-29-19-12-38.webm](https://github.com/user-attachments/assets/0a9fd89d-ecbb-49a9-b5be-8391cdccc2d3)

To be clear I have no idea why this bug doesn't apply to the jetpack upgrade recipies generated, it just didn't lol. Sorry if there are also better ways to fix this, I'm like 4 days into learning this neoforge development stuff.